### PR TITLE
Add ability to process csvs as test input and display results

### DIFF
--- a/src/commands/text-completion.ts
+++ b/src/commands/text-completion.ts
@@ -41,7 +41,7 @@ export default class TextCompletion extends Command {
 
     const client = this.providerToClient(flags.provider)
 
-    const result = await client.textCompletion('gpt-3.5-turbo', 0, 'can you write me a 10 line poem to hype up a internal medicine intern')
+    const result = await client.textCompletion('gpt-3.5-turbo', 0, '', 'can you write me a 10 line poem to hype up a internal medicine intern')
 
     console.log(result)
   }

--- a/src/providers/base/llm-base.ts
+++ b/src/providers/base/llm-base.ts
@@ -1,5 +1,5 @@
 export class LLMBase {
-  textCompletion(model: string, temperature: number, message: string): Promise<string> {
-    return Promise.resolve(`model: ${model}, temperature: ${temperature}, message: ${message}`)
+  textCompletion(model: string, temperature: number, prompt: string, message: string): Promise<string> {
+    return Promise.resolve(`model: ${model}, temperature: ${temperature}, prompt: ${prompt}, message: ${message}`)
   }
 }

--- a/src/providers/openai/llm.ts
+++ b/src/providers/openai/llm.ts
@@ -13,12 +13,18 @@ export class LLM extends LLMBase {
     this.client = new OpenAIApi(configuration)
   }
 
-  async textCompletion(model: string, temperature: number, message: string): Promise<string> {
+  async textCompletion(model: string, temperature: number, prompt: string, message: string): Promise<string> {
     return new Promise((resolve, _reject) => {
       this.client.createChatCompletion({
         model,
         temperature,
-        messages: [{ role: 'user', content: message }],
+        messages: [
+          {
+            role: 'system',
+            content: prompt,
+          },
+          { role: 'user', content: message },
+        ],
       }).then(chatCompletion => {
         console.log(chatCompletion.data.choices[0].message)
         resolve(chatCompletion.data.choices[0].message?.content || 'error')


### PR DESCRIPTION
Sample output:

```
./bin/dev file examples/sentiment-analysis/Waffiefile                                                                                         12.5s  Tue Jul 25 08:44:29 2023
Testing openai:
{ role: 'assistant', content: 'positive' }
{ processedRow: 'positive', expected: 'positive' }
{ role: 'assistant', content: 'neutral' }
{ processedRow: 'neutral', expected: 'neutral' }
{ role: 'assistant', content: 'negative' }
{ processedRow: 'negative', expected: 'negative' }
{ role: 'assistant', content: 'positive' }
{ processedRow: 'positive', expected: 'positive' }
{ role: 'assistant', content: 'neutral' }
{ processedRow: 'neutral', expected: 'neutral' }
{ role: 'assistant', content: 'negative' }
{ processedRow: 'negative', expected: 'negative' }
{ role: 'assistant', content: 'positive' }
{ processedRow: 'positive', expected: 'positive' }
{ role: 'assistant', content: 'Neutral' }
{ processedRow: 'neutral', expected: 'neutral' }
{ role: 'assistant', content: 'negative' }
{ processedRow: 'negative', expected: 'negative' }
{ role: 'assistant', content: 'positive' }
{ processedRow: 'positive', expected: 'positive' }
{ role: 'assistant', content: 'positive' }
{ processedRow: 'positive', expected: 'positive' }
{ role: 'assistant', content: 'neutral' }
{ processedRow: 'neutral', expected: 'neutral' }
{ role: 'assistant', content: 'negative' }
{ processedRow: 'negative', expected: 'negative' }
{ role: 'assistant', content: 'Sentiment: Positive' }
{ processedRow: 'sentiment: positive', expected: 'positive' }
{ role: 'assistant', content: 'Neutral' }
{ processedRow: 'neutral', expected: 'neutral' }
{ role: 'assistant', content: 'negative' }
{ processedRow: 'negative', expected: 'negative' }
{ role: 'assistant', content: 'positive' }
{ processedRow: 'positive', expected: 'positive' }
{ role: 'assistant', content: 'neutral' }
{ processedRow: 'neutral', expected: 'neutral' }
{ role: 'assistant', content: 'negative' }
{ processedRow: 'negative', expected: 'negative' }
{ role: 'assistant', content: 'positive' }
{ processedRow: 'positive', expected: 'positive' }
{ role: 'assistant', content: 'neutral' }
{ processedRow: 'neutral', expected: 'neutral' }
{ role: 'assistant', content: 'negative' }
{ processedRow: 'negative', expected: 'negative' }
Results for /Users/rogerlam/waffie/examples/sentiment-analysis/test/feedback.csv: 21/22
```